### PR TITLE
feature(util): Wrap `pthread` to support better opeation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(client-cpp LANGUAGES CXX)
+
+# GoogleTest requires are least C++14
+set(CMAKE_CXX_STANDARD 14)
+
+# Here, we must include the CTest, because we
+# call `enabletesting` internally.
+# See https://stackoverflow.com/questions/13550153/no-tests-found-when-using-gtest-with-cmake-ctest
+include(CTest)
+
+# Here we use CMake `FetchContent` module to download
+# the dependency to the build system
+# See https://cmake.org/cmake/help/latest/module/FetchContent.html
+# And the code snippet is copied from the GTest docs.
+# See https://google.github.io/googletest/quickstart-cmake.html
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG release-1.12.1
+)
+FetchContent_MakeAvailable(googletest)
+
+# See https://cmake.org/cmake/help/latest/module/FindDoxygen.html
+find_package(Doxygen
+             REQUIRED dot
+             OPTIONAL_COMPONENTS mscgen dia)
+
+if (DOXYGEN_FOUND)
+  set(DOXYGEN_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/docs)
+  # Here we must make Doxygen do not generate
+  # the docs for dependency
+  # See https://cmake.org/cmake/help/latest/module/FindDoxygen.html#variable:DOXYGEN_EXCLUDE_PATTERNS
+  set(DOXYGEN_EXCLUDE_PATTERNS "*/_deps/*")
+  doxygen_add_docs(DOXYGEN ${PROJECT_SOURCE_DIR})
+  set(DOXYGEN_COLLABORATION_GRAPH YES)
+  set(DOXYGEN_EXTRACT_ALL YES)
+  set(DOXYGEN_CLASS_DIAGRAMS YES)
+  set(DOXYGEN_HIDE_UNDOC_RELATIONS NO)
+  set(DOXYGEN_HAVE_DOT YES)
+  set(DOXYGEN_CLASS_GRAPH YES)
+  set(DOXYGEN_CALL_GRAPH YES)
+  set(DOXYGEN_CALLER_GRAPH YES)
+  set(DOXYGEN_COLLABORATION_GRAPH YES)
+  set(DOXYGEN_BUILTIN_STL_SUPPORT YES)
+  set(DOXYGEN_EXTRACT_PRIVATE YES)
+  set(DOXYGEN_EXTRACT_PACKAGE YES)
+  set(DOXYGEN_EXTRACT_STATIC YES)
+  set(DOXYGEN_EXTRACT_LOCALMETHODS YES)
+  set(DOXYGEN_UML_LOOK YES)
+  set(DOXYGEN_UML_LIMIT_NUM_FIELDS 50)
+  set(DOXYGEN_TEMPLATE_RELATIONS YES)
+  set(DOXYGEN_DOT_GRAPH_MAX_NODES 100)
+  set(DOXYGEN_MAX_DOT_GRAPH_DEPTH 0)
+  set(DOXYGEN_DOT_TRANSPARENT YES)
+else()
+  message("Doxygen need to be installed to generate the doxygen documentation")
+endif()
+
+add_subdirectory(./util)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(./os)

--- a/util/os/CMakeLists.txt
+++ b/util/os/CMakeLists.txt
@@ -1,0 +1,4 @@
+
+add_subdirectory(./tests)
+
+add_library(util_os STATIC thread.cpp thread.hpp)

--- a/util/os/tests/CMakeLists.txt
+++ b/util/os/tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+enable_testing()
+
+add_executable(
+  thread_test
+  thread_test.cpp
+)
+
+target_include_directories(thread_test PRIVATE ../../os)
+
+target_link_libraries(
+  thread_test
+  util_os
+  GTest::gtest_main
+)
+
+include(GoogleTest)
+gtest_discover_tests(thread_test)

--- a/util/os/tests/thread_test.cpp
+++ b/util/os/tests/thread_test.cpp
@@ -1,0 +1,58 @@
+#include "thread.hpp"
+#include <gtest/gtest.h>
+
+thread::Lock mutex{};
+thread::Cond cond{};
+
+static const int threadNum = 4;
+
+int addOne(int n) {
+  thread::LockGuard guard{&mutex.l};
+  return n + 1;
+}
+
+void *addTest(void *num) {
+  int *n = reinterpret_cast<int *>(num);
+  for (int i = 0; i < 100; ++i) {
+    *n = addOne(*n);
+  }
+  return nullptr;
+}
+
+void *barrier(void *num) {
+  int *n = reinterpret_cast<int *>(num);
+  cond.lock();
+  *n = *n + 1;
+
+  if (*n % threadNum == 0) {
+    cond.signal();
+  } else {
+    cond.boradcast();
+  }
+  cond.unlock();
+  return nullptr;
+}
+
+TEST(ThreadTest, MutexGuard) {
+  pthread_t thread1, thread2;
+
+  int num = 0;
+  pthread_create(&thread1, nullptr, addTest, &num);
+  pthread_create(&thread2, nullptr, addTest, &num);
+  pthread_join(thread1, nullptr);
+  pthread_join(thread2, nullptr);
+
+  ASSERT_EQ(num, 200);
+}
+
+TEST(ThreadTest, Cond) {
+  pthread_t thread_[threadNum];
+  int count = 0;
+  for (int i = 0; i < threadNum; ++i) {
+    pthread_create(&thread_[i], nullptr, barrier, &count);
+  }
+  for (int i = 0; i < threadNum; ++i) {
+    pthread_join(thread_[i], nullptr);
+  }
+  ASSERT_EQ(count, 4);
+}

--- a/util/os/thread.cpp
+++ b/util/os/thread.cpp
@@ -1,0 +1,24 @@
+#include "thread.hpp"
+
+using namespace thread;
+
+Lock::Lock() { pthread_mutex_init(&l, NULL); }
+
+LockGuard::LockGuard(pthread_mutex_t *l) : lock(l) { pthread_mutex_lock(lock); }
+
+LockGuard::~LockGuard() { pthread_mutex_unlock(lock); }
+
+Cond::Cond() {
+  pthread_mutex_init(&l, NULL);
+  pthread_cond_init(&c, NULL);
+}
+
+void Cond::lock() { pthread_mutex_lock(&l); }
+
+void Cond::unlock() { pthread_mutex_unlock(&l); }
+
+void Cond::wait() { pthread_cond_wait(&c, &l); }
+
+void Cond::signal() { pthread_cond_signal(&c); }
+
+void Cond::boradcast() { pthread_cond_broadcast(&c); }

--- a/util/os/thread.hpp
+++ b/util/os/thread.hpp
@@ -1,0 +1,117 @@
+/**
+ * @file thread.hpp
+ * @brief Wrap the pthread library
+ *
+ * This file wrap the some functions of the pthread library
+ * to provide some better abstract classes for better use.
+ */
+
+#include <pthread.h>
+
+namespace thread {
+
+/**
+ * @brief Used for wrap pthread `pthread_mutex_t`
+ */
+class Lock {
+public:
+  pthread_mutex_t l;
+
+  /**
+   * @brief Construct a new Lock object
+   *
+   * Use constructor to initialize the mutex lock
+   */
+  explicit Lock();
+
+  /**
+   * @brief Disable copy constructor
+   */
+  Lock(const Lock &) = delete;
+  Lock &operator=(const Lock &) = delete;
+};
+
+/**
+ * @brief RAII wrapper for lock and unlock operation
+ */
+class LockGuard {
+private:
+  pthread_mutex_t *lock;
+
+public:
+  /**
+   * @brief Disable default constructor
+   */
+  LockGuard() = delete;
+
+  /**
+   * @brief Construct a new Lock Guard object
+   *
+   * Lock the mutex
+   *
+   * @param l the pointer to the lock
+   */
+  explicit LockGuard(pthread_mutex_t *l);
+
+  LockGuard(const LockGuard &) = delete;
+  LockGuard(LockGuard &&) = delete;
+  LockGuard &operator=(const LockGuard &) = delete;
+
+  /**
+   * @brief Destroy the Lock Guard object
+   *
+   * Unlock the mutex
+   */
+  ~LockGuard();
+};
+
+/**
+ * @brief Used for wrap a pair of cond and mutex
+ *
+ * For conditon variable, we often need to use a mutex
+ * with it, so this class simply wraps the two, unlike
+ * @link Lock @endlink and @link LockGuard @endlink
+ * which you don't use `lock` and `unlock` operations
+ * explictily. You need to explicitly lock and unlock.
+ */
+class Cond {
+private:
+  pthread_mutex_t l;
+  pthread_cond_t c;
+
+public:
+  /**
+   * @brief Construct a new Cond object
+   */
+  explicit Cond();
+
+  Cond(const Cond &) = delete;
+  Cond &operator=(const Cond &) = delete;
+
+  /**
+   * @brief Lock the mutex
+   */
+  void lock();
+
+  /**
+   * @brief Unlock the mutex
+   */
+  void unlock();
+
+  /**
+   * @brief Wait for the cond
+   */
+  void wait();
+
+  /**
+   * @brief Signal for the cond
+   */
+  void signal();
+
+  /**
+   * @brief Boradcast for the cond
+   */
+  void boradcast();
+};
+
+} // namespace thread


### PR DESCRIPTION
This commit uses three classes to wrap some `pthread` library functions
and make better use of the lock and cond.

1. `Lock`: Initialize a new mutex.
2. `LockGuard`: Use RAII to lock the mutex and unlock the mutex.
3. `Cond`: Used for wrap a pair of cond and mutex