### PR TITLE
docs: Add README and CONTRIBUTION guideline

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,234 @@
+<type>(<scope>): <summary>
+
+<Describe the motivation behind this change - explain WHY you are making this change. Wrap all lines
+at 100 characters.>
+
+Fixes #<issue number>
+
+# ────────────────────────────────────────── 100 chars ────────────────────────────────────────────┤
+
+# Example Commit Messages
+
+# =======================
+
+# ─── Example: Simple refactor ────────────────────────────────────────────────────────────────────┤
+
+# refactor(core): rename refreshDynamicEmbeddedViews to refreshEmbeddedViews
+
+#
+
+# Improve code readability. The original name no longer matches how the function is used
+
+# ─────────────────────────────────────────────────────────────────────────────────────────────────┤
+
+# ─── Example: Simple docs change ─────────────────────────────────────────────────────────────────┤
+
+# docs: clarify the service limitation in providers.md guide
+
+#
+
+# Fixes #36332
+
+# ─────────────────────────────────────────────────────────────────────────────────────────────────┤
+
+# ─── Example: A bug fix ──────────────────────────────────────────────────────────────────────────┤
+
+# fix(ngcc): ensure lockfile is removed when `analyzeFn` fails
+
+#
+
+# Previously an error thrown in the `analyzeFn` would cause the ngcc process to exit immediately
+
+# without removing the lockfile, and potentially before the unlocker process had been successfully
+
+# spawned resulting in the lockfile being orphaned and left behind
+
+#
+
+# Now we catch these errors and remove the lockfile as needed
+
+# ─────────────────────────────────────────────────────────────────────────────────────────────────┤
+
+# ─── Example: Breaking change ────────────────────────────────────────────────────────────────────┤
+
+# feat(bazel): simplify ng_package by dropping esm5 and fesm5
+
+#
+
+# esm5 and fesm5 distributions are no longer needed and have been deprecated in the past
+
+#
+
+# <https://v9.angular.io/guide/deprecations#esm5-and-fesm5-code-formats-in-angular-npm-packages>
+
+#
+
+# This commit modifies ng_package to no longer distribute these two formats in npm packages built by
+
+# ng_package (e.g. @angular/core)
+
+#
+
+# This commit intentionally doesn't fully clean up the ng_package rule to remove all traces of esm5
+
+# and fems5 build artifacts as that is a bigger cleanup and currently we are narrowing down the
+
+# scope of this change to the MVP needed for v10, which in this case is 'do not put esm5 and fesm5'
+
+# into the npm packages
+
+#
+
+# More cleanup to follow: <https://angular-team.atlassian.net/browse/FW-2143>
+
+#
+
+# BREAKING CHANGE: esm5 and fesm5 format is no longer distributed in Angular's npm packages e.g
+
+# @angular/core
+
+#
+
+# Angular CLI will automatically downlevel the code to es5 if differential loading is enabled in the
+
+# Angular project, so no action is required from Angular CLI users
+
+#
+
+# If you are not using Angular CLI to build your application or library, and you need to be able to
+
+# build es5 artifacts, then you will need to downlevel the distributed Angular code to es5 on your
+
+# own
+
+#
+
+#
+
+# Fixes #1234
+
+# ─────────────────────────────────────────────────────────────────────────────────────────────────┤
+
+# Commit Message Format
+
+# =============================
+
+#
+
+# The following is an excerpt of the specification with the most commonly needed info
+
+#
+
+# Each commit message consists of a *header*, a *body*, and a *footer*
+
+#
+
+# <header>
+
+# <BLANK LINE>
+
+# <body>
+
+# <BLANK LINE>
+
+# <footer>
+
+#
+
+# The header is mandatory
+
+#
+
+# The body is mandatory for all commits except for those of scope "docs". When the body is required
+
+# it must be at least 20 characters long
+
+#
+
+# The footer is optional
+
+#
+
+# Any line of the commit message cannot be longer than 100 characters
+
+#
+
+#
+
+# Commit Message Header
+
+# ---------------------
+
+#
+
+# <type>(<scope>): <short summary>
+
+# │       │             │
+
+# │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end
+
+# │       │
+
+# │       └─⫸ Commit Scope: util (and other scopes)
+
+# │
+
+# └─⫸ Commit Type: build|ci|docs|feature|fix|refactor|style|test|perf|
+
+# Commit Message Body
+
+# ---------------------
+
+#
+
+# Just as in the summary, use the imperative, present tense: "fix" not "fixed" nor "fixes"
+
+#
+
+# Explain the motivation for the change in the commit message body. This commit message should
+
+# explain WHY you are making the change. You can include a comparison of the previous behavior with
+
+# the new behavior in order to illustrate the impact of the change
+
+#
+
+#
+
+# Commit Message Footer
+
+# ---------------------
+
+#
+
+# The footer can contain information about breaking changes and is also the place to reference
+
+# GitHub issues, Jira tickets, and other PRs that this commit closes or is related to
+
+#
+
+# ```
+
+# BREAKING CHANGE: <breaking change summary>
+
+# <BLANK LINE>
+
+# <breaking change description + migration instructions>
+
+# <BLANK LINE>
+
+# <BLANK LINE>
+
+# Fixes #<issue number>
+
+# ```
+
+#
+
+# Breaking Change section should start with the phrase "BREAKING CHANGE: " followed by a summary of
+
+# the breaking change, a blank line, and a detailed description of the breaking change that also
+
+# includes migration instructions
+
+#

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,215 @@
+<!-- This part is copied from Angular project -->
+
+# Contributing to client-cpp
+
+## Submission Guidelines
+
+### Submitting a Pull Request (PR)
+
+Before you submit your Pull Request (PR) consider the following guidelines:
+
+1. Search GitHub for an open or closed PR that relates to your submission. You don't
+want to duplicate existing efforts.
+2. Be sure that an issue describes the problem you're fixing, or documents the design
+for the feature you'd like to add. Discussing the design upfront helps to ensure that
+we're ready to accept your work.
+3. Fork the repository.
+4. In your forked repository, make your changes in a new git branch:
+
+   ```sh
+   git checkout -b my-fix-branch master
+   ```
+
+5. Create your patch, **including appropriate test cases**.
+6. Run the full test suite and ensure that all tests pass.
+
+   ```sh
+   mkdir build && cd build && cmake .. && cmake --build . && ctest
+   ```
+
+7. Commit your changes using a descriptive commit message that follows our commit
+message conventions.
+8. Push your branch to GitHub:
+
+   ```sh
+   git push origin my-fix-branch
+   ```
+
+9. In GitHub, send a pull request to `client-cpp:master`.
+
+### Reviewing a Pull Request
+
+#### Addressing review feedback
+
+1. Make the required updates to the code.
+2. Re-run the test suites to ensure tests are still passing.
+3. Create a fixup commit and push to your GitHub repository (this will update your
+Pull Request):
+
+  ```sh
+  git commit --all --fixup HEAD
+  git push
+  ```
+
+That's it! Thank you for your contribution!
+
+#### Updating the commit message
+
+A reviewer might often suggest changes to a commit message. In order to update the
+commit message of the last commit on your branch:
+
+1. Check out your branch:
+
+   ```sh
+   git checkout my-fix-branch
+   ```
+
+2. Amend the last commit and modify the commit message:
+
+   ```sh
+   git commit --amend
+   ```
+
+3. Push to your GitHub repository:
+
+   ```sh
+   git push --force-with-lease
+   ```
+
+#### After your pull request is merged
+
+After your pull request is merged, you can safely delete your branch and pull the
+changes from the master (upstream) repository:
+
++ Delete the remote branch on GitHub either through the GitHub web UI or your local
+shell as follows:
+
+  ```sh
+  git push origin --delete my-fix-branch
+  ```
+
++ Check out the master branch:
+
+  ```sh
+  git checkout master -f
+  ```
+
++ Delete the local branch:
+
+  ```sh
+  git branch -D my-fix-branch
+  ```
+
++ Update your local `master` with the latest upstream version:
+
+  ```sh
+  git pull --ff upstream main
+  ```
+
+## Commit Message Format
+
+We have very precise rules over how our Git commit messages must be formatted. This
+format leads to easier to read commit history.
+
+Each commit message consists of a *header*, a *body*, and a *footer*.
+
+```
+<header>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The header is mandatory and must conform to the Commit Message Header format.
+
+The body is mandatory for all commits. When the body is present it must be at least
+20 characters long and must conform to the Commit Message Body format.
+
+The footer is optional. The Commit Message Footer format describes what the footer is used for and the structure it must have.
+
+### Commit Message Header
+
+```
+<type>(<scope>): <short summary>
+  │       │             │
+  │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
+  │       │
+  │       └─⫸ Commit Scope: util (and some other scopes)
+  │
+  └─⫸ Commit Type: build|ci|docs|feature|fix|refactor|test|perf|
+```
+
+The `<type>` and `<summary>` fields are mandatory, the `(<scope>)` field is optional.
+
+#### Type
+
+Must be one of the following:
+
++ build: Changes that affect the build system or external dependencies
++ ci: Changes to our CI configuration files and scripts
++ docs: Documentation only changes
++ feature: A new feature
++ fix: A bug fix
++ perf: A code change that improves performance
++ refactor: A code change that neither fixes a bug nor adds a feature
++ test: Adding missing tests or correcting existing tests
+
+#### Summary
+
+Use the summary field to provide a succinct description of the change:
+
++ use the imperative, present tense: "change" not "changed" nor "changes"
++ don't capitalize the first letter
++ no dot (.) at the end
+
+### Commit Message Body
+
+Just as in the summary, use the imperative, present tense: "fix" not "fixed" nor "fixes".
+
+Explain the motivation for the change in the commit message body. This commit message should explain
+why you are making the change. You can include a comparison of the previous behavior with the new
+behavior in order to illustrate the impact of the change.
+
+### Commit Message Footer
+
+The footer can contain information about breaking changes and deprecations and is also the place to
+reference GitHub issues, Jira tickets, and other PRs that this commit closes or is related to. For
+example:
+
+```
+BREAKING CHANGE: <breaking change summary>
+<BLANK LINE>
+<breaking change description + migration instructions>
+<BLANK LINE>
+<BLANK LINE>
+Fixes #<issue number>
+```
+
+or
+
+```
+DEPRECATED: <what is deprecated>
+<BLANK LINE>
+<deprecation description + recommended update path>
+<BLANK LINE>
+<BLANK LINE>
+Closes #<pr number>
+```
+
+Breaking Change section should start with the phrase "BREAKING CHANGE: " followed by a summary of the
+breaking change, a blank line, and a detailed description of the breaking change that also includes
+migration instructions.
+
+Similarly, a Deprecation section should start with "DEPRECATED: " followed by a short description of
+what is deprecated, a blank line, and a detailed description of the deprecation that also mentions the
+recommended update path.
+
+### Revert commits
+
+If the commit reverts a previous commit, it should begin with `revert:` , followed by the header of the reverted commit.
+
+The content of the commit message body should contain:
+
+1. information about the SHA of the commit being reverted in the following format: This reverts commit `<SHA>`,
+2. a clear description of the reason for reverting the commit message.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Client-cpp
+
+Client-cpp is aimed at interact with k8s and provides the basic
+functionality which client-go has provided.
+
+## Development Setup
+
+For setting up the development environment. You must develope in
+the UNIX-like environment with the following requirements:
+
++ Latest `gcc` or `clang` for compilation.
++ Latest `cmake` for building the project.
++ `clang-format` for formatting the code.
++ Doxygen and graphviz for building the docs.
+
+## Contributing
+
+Read through our [contributing guidelines](CONTRIBUTING.md) to learn about our
+submission process, coding rules and more.


### PR DESCRIPTION
This commit adds README and CONTRIBUTION guideline. The CONTRIBUTION
guide line is copied from angular/angular repo.

And also this commits add `.gitmessage`. For every commit, the template
would occur for simplicity.